### PR TITLE
Fix error while creating the initial session table

### DIFF
--- a/TitanReputations.lua
+++ b/TitanReputations.lua
@@ -324,8 +324,8 @@ local function prepareSessionTable()
 	local numFactions = GetNumFactions()
 	for factionIndex = 1, numFactions do
 		local name, _, _, _, _, earnedValue, _, _, _, _, _, _, _, factionId = GetFactionInfo(factionIndex)
-		local friendID, friendRep = GetFriendshipReputation(factionId)
 		if (factionId) then
+			local friendID, friendRep = GetFriendshipReputation(factionId)
 			if (IsMajorFaction(factionId)) then
 				local data = GetMajorFactionData(factionId)
 				local isCapped = HasMaximumRenown(factionId)


### PR DESCRIPTION
factionId could be nil, which errors in GetFriendshipReputation.

```
12x Usage: local reputationInfo = C_GossipInfo.GetFriendshipReputation(friendshipFactionID)
[string "=[C]"]: in function 'GetFriendshipReputation'
[string "@TitanReputations/TitanReputations.lua"]:21: in function <TitanReputations/TitanReputations.lua:20>
[string "@TitanReputations/TitanReputations.lua"]:327: in function <TitanReputations/TitanReputations.lua:323>
[string "@TitanReputations/TitanReputations.lua"]:351: in function '?'
[string "@TitanReputations/Libs/Elib-4.0-12/Elib-4.0.lua"]:168: in function <...eTitanReputations/Libs/Elib-4.0/Elib-4.0.lua:168>
```