### PR TITLE
Fix "IsFactionParagon" error in SoD

### DIFF
--- a/TitanReputations.lua
+++ b/TitanReputations.lua
@@ -18,8 +18,9 @@ Color.ORANGE = "|cFFE77324"
 
 local SEX = UnitSex("player")
 
+local IsFactionParagon = C_Reputation.IsFactionParagon
 -- Not available in Classic Era/SoD
-local IsFactionParagon = C_Reputation.IsFactionParagon and C_Reputation.IsFactionParagon or function(factionId) return false end
+IsFactionParagon = IsFactionParagon or nop
 
 local GetFriendshipReputation = GetFriendshipReputation
 if not GetFriendshipReputation and C_GossipInfo and C_GossipInfo.GetFriendshipReputation then

--- a/TitanReputations.lua
+++ b/TitanReputations.lua
@@ -18,10 +18,6 @@ Color.ORANGE = "|cFFE77324"
 
 local SEX = UnitSex("player")
 
-local IsFactionParagon = C_Reputation.IsFactionParagon
--- Not available in Classic Era/SoD
-IsFactionParagon = IsFactionParagon or nop
-
 local GetFriendshipReputation = GetFriendshipReputation
 if not GetFriendshipReputation and C_GossipInfo and C_GossipInfo.GetFriendshipReputation then
 	GetFriendshipReputation = function(factionId)
@@ -40,6 +36,7 @@ end
 GetFriendshipReputation = GetFriendshipReputation or nop
 
 local IsMajorFaction = C_Reputation.IsMajorFaction or nop
+local IsFactionParagon = C_Reputation.IsFactionParagon or nop
 local GetMajorFactionData = C_MajorFactions and C_MajorFactions.GetMajorFactionData and C_MajorFactions.GetMajorFactionData or nop
 local HasMaximumRenown = C_MajorFactions and C_MajorFactions.HasMaximumRenown and C_MajorFactions.HasMaximumRenown or nop
 local GetCurrentRenownLevel = C_MajorFactions and C_MajorFactions.GetCurrentRenownLevel or nop

--- a/TitanReputations.lua
+++ b/TitanReputations.lua
@@ -18,6 +18,9 @@ Color.ORANGE = "|cFFE77324"
 
 local SEX = UnitSex("player")
 
+-- Not available in Classic Era/SoD
+local IsFactionParagon = C_Reputation.IsFactionParagon and C_Reputation.IsFactionParagon or function(factionId) return false end
+
 local GetFriendshipReputation = GetFriendshipReputation
 if not GetFriendshipReputation and C_GossipInfo and C_GossipInfo.GetFriendshipReputation then
 	GetFriendshipReputation = function(factionId)
@@ -177,7 +180,7 @@ local function GetValueAndMaximum(standingId, barValue, bottomValue, topValue, f
 		local standingText = " (" .. (RENOWN_LEVEL_LABEL .. data.renownLevel) .. ")"
 		local session = GetBalanceForMajorFaction(factionId, current, data.renownLevel)
 		local texture = MajorFactionTexture(data)
-		if (C_Reputation.IsFactionParagon(factionId)) then
+		if (IsFactionParagon(factionId)) then
 			return GetParagonValues(barValue, factionId, colors, texture)
 		end
 		return current, data.renownLevelThreshold, colors.renown, standingText, nil, session, texture
@@ -187,7 +190,7 @@ local function GetValueAndMaximum(standingId, barValue, bottomValue, topValue, f
 		return "0", "0", "|cFFFF0000", "??? - " .. (factionId .. "?")
 	end
 
-	if (C_Reputation.IsFactionParagon(factionId)) then
+	if (IsFactionParagon(factionId)) then
 		return GetParagonValues(barValue, factionId, colors)
 	end
 
@@ -377,7 +380,7 @@ local function GetTooltipText(self, id)
 					show = false
 				end
 
-				if (alwaysShowParagon and C_Reputation.IsFactionParagon(factionId)) then
+				if (alwaysShowParagon and IsFactionParagon(factionId)) then
 					show = true
 				end
 


### PR DESCRIPTION
Fixes the following error in SoD

```
attempt to call field 'IsFactionParagon' (a nil value) ....
```

![image](https://github.com/user-attachments/assets/a30f09a0-b8cc-457c-851a-14c4fef522db)


See also [this report](https://legacy.curseforge.com/wow/addons/titan-panel-reputation/issues/9)